### PR TITLE
修复脚手架中的 .gitignore 文件不能被正确复制的问题

### DIFF
--- a/src/renderer/models/projectCreate.js
+++ b/src/renderer/models/projectCreate.js
@@ -230,7 +230,7 @@ export default {
         dot: true
       }).forEach((source) => {
         const subDir = source.replace(/__(\w+)__/g, (match, offset) => initSetting[offset]);
-        const target = join(initSetting.projPath, subDir).replace('.npmignore', '.gitignore');
+        const target = join(initSetting.projPath, subDir).replace(/\.npmignore$/, '.gitignore');
         if (existsSync(target)) {
           overwriteFiles.push(source);
         }
@@ -276,7 +276,7 @@ export default {
         }
         const subDir = source.replace(/__(\w+)__/g, (match, offset) => initSetting[offset]);
 
-        const target = join(initSetting.projPath, subDir).replace('.npmignore', '.gitignore');
+        const target = join(initSetting.projPath, subDir).replace(/\.npmignore$/, '.gitignore');
 
         mkdirp.sync(dirname(target));
 

--- a/src/renderer/models/projectCreate.js
+++ b/src/renderer/models/projectCreate.js
@@ -230,7 +230,7 @@ export default {
         dot: true
       }).forEach((source) => {
         const subDir = source.replace(/__(\w+)__/g, (match, offset) => initSetting[offset]);
-        const target = join(initSetting.projPath, subDir);
+        const target = join(initSetting.projPath, subDir).replace('.npmignore', '.gitignore');
         if (existsSync(target)) {
           overwriteFiles.push(source);
         }
@@ -276,7 +276,7 @@ export default {
         }
         const subDir = source.replace(/__(\w+)__/g, (match, offset) => initSetting[offset]);
 
-        const target = join(initSetting.projPath, subDir);
+        const target = join(initSetting.projPath, subDir).replace('.npmignore', '.gitignore');
 
         mkdirp.sync(dirname(target));
 


### PR DESCRIPTION
https://github.com/npm/npm/issues/1862
`npm publish` 时 会将 `.gitignore` 重命名为 `.npmignore`，
在生成目录时需要反重命名回来。